### PR TITLE
fix kelly rowland name misspell

### DIFF
--- a/_posts/2014-11-19-origen-and-open-source.markdown
+++ b/_posts/2014-11-19-origen-and-open-source.markdown
@@ -11,7 +11,7 @@ tags: meeting
 
 - Max Fratonni
 - Katy Hufff
-- Kelly Rowlend
+- Kelly Rowland
 - Alejandra Jolodowski
 - Sandra Bogetich
 - Maddykin Munk


### PR DESCRIPTION
This fixes the misspelling of 'Rowland' in the 2014-11-19 post.
