### PR TITLE
added requirements file so people can pip install -r requirements.txt

### DIFF
--- a/scraping/requirements.txt
+++ b/scraping/requirements.txt
@@ -1,0 +1,6 @@
+# These are the libraries needed to run this webscraping_tutorial
+
+html5lib>=0.9999999
+pandas>=0.17.0
+requests>=2.8.1
+lxml>=3.4.4


### PR DESCRIPTION
Here is a separate file that with `pip install -r requirements.txt` (`pip3 install -r requirements.txt` for python3) people can install all the required packages. 