### PR TITLE
update times on index page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,8 +49,8 @@ We meet at the [Berkeley Institute for Data Science](https://bids.berkeley.edu).
 
 ## When:
 
-Wednesdays at 4pm (Berkeley time -- starting officially at 4:10, but have a friendly chat from 4:00-4:10 if you like). While the main session should occupy less than an hour, the
-lightning talks and hacking session usually go on until 5:30pm. See the [upcoming topics list]({{ site.url }}/upcoming.html)
+Wednesdays at 4pm (Berkeley time -- starting officially at 5:10, but have a friendly chat from 5:00-5:10 if you like). While the main session should occupy less than an hour, the
+lightning talks and hacking session usually go on until 6:30pm. See the [upcoming topics list]({{ site.url }}/upcoming.html)
 or the [calendar](http://bit.ly/1cqFKuh)
 for the topic for this week.
 
@@ -65,7 +65,7 @@ for the topic for this week.
 
 Participating is really easy.
 <ul>
-<li>At **4:00pm**, we gather and go through a round of introductions.
+<li>At **5:00pm**, we gather and go through a round of introductions.
 New faces are always appearing!</li>
 <li>Next, a volunteer will give a **tutorial** or lead a
 **discussion** about a


### PR DESCRIPTION
I won't be able to make this week, but some of my colleagues might if I send a link around. All the times are moved back an hour for this semester, right?